### PR TITLE
Second Version

### DIFF
--- a/babel-algebraic-effects/src/index.js
+++ b/babel-algebraic-effects/src/index.js
@@ -266,8 +266,8 @@ traverse.default(ast, {
       t.objectMethod(
         'method',
         t.Identifier('handle'),
-        [t.Identifier('effect'), t.Identifier('next')],
-        node.handleEffects
+        [node.handleEffects.param, t.Identifier('next')],
+        node.handleEffects.body
       )
     )
 

--- a/babel/packages/babel-parser/src/parser/expression.js
+++ b/babel/packages/babel-parser/src/parser/expression.js
@@ -2223,6 +2223,7 @@ export default class ExpressionParser extends LValParser {
   }
 
   isAwaitAllowed(): boolean {
+    if (this.scope.inHandleBlock) return true;
     if (this.scope.inFunction) return this.scope.inAsync;
     if (this.options.allowAwaitOutsideFunction) return true;
     if (this.hasPlugin("topLevelAwait")) return this.inModule;

--- a/babel/packages/babel-parser/src/parser/statement.js
+++ b/babel/packages/babel-parser/src/parser/statement.js
@@ -690,7 +690,19 @@ export default class StatementParser extends ExpressionParser {
       node.handler = this.finishNode(clause, "CatchClause");
     }
 
-    node.handleEffects = this.eat(tt._handle) ? this.parseBlock() : null;
+    node.handleEffects = null;
+    if (this.eat(tt._handle)) {
+      const clause = this.startNode();
+      this.next();
+
+      clause.param = this.parseBindingAtom();
+      this.next();
+
+      clause.body = this.parseBlock();
+      this.scope.exit();
+
+      node.handleEffects = this.finishNode(clause, "HandleEffectClause");
+    }
     node.finalizer = this.eat(tt._finally) ? this.parseBlock() : null;
 
     if (!node.handler && !node.handleEffects && !node.finalizer) {

--- a/babel/packages/babel-parser/src/parser/statement.js
+++ b/babel/packages/babel-parser/src/parser/statement.js
@@ -698,7 +698,9 @@ export default class StatementParser extends ExpressionParser {
       clause.param = this.parseBindingAtom();
       this.next();
 
-      clause.body = this.parseBlock();
+      this.scope.inHandleBlock = true;
+      clause.body = this.parseBlock(false, false);
+      this.scope.inHandleBlock = false;
       this.scope.exit();
 
       node.handleEffects = this.finishNode(clause, "HandleEffectClause");

--- a/babel/packages/babel-parser/src/types.js
+++ b/babel/packages/babel-parser/src/types.js
@@ -267,13 +267,19 @@ export type ThrowStatement = NodeBase & {
 export type TryStatement = NodeBase & {
   type: "TryStatement",
   block: BlockStatement,
-  handleEffects: BlockStatement | null,
+  handleEffects: HandleEffectClause | null,
   handler: CatchClause | null,
   finalizer: BlockStatement | null,
 };
 
 export type CatchClause = NodeBase & {
   type: "CatchClause",
+  param: Pattern,
+  body: BlockStatement,
+};
+
+export type HandleEffectClause = NodeBase & {
+  type: "HandleEffectClause",
   param: Pattern,
   body: BlockStatement,
 };

--- a/babel/packages/babel-parser/src/util/scope.js
+++ b/babel/packages/babel-parser/src/util/scope.js
@@ -49,6 +49,8 @@ export default class ScopeHandler<IScope: Scope = Scope> {
     this.inModule = inModule;
   }
 
+  inHandleBlock = false;
+
   get inFunction() {
     return (this.currentVarScope().flags & SCOPE_FUNCTION) > 0;
   }

--- a/samples/basic.js
+++ b/samples/basic.js
@@ -14,6 +14,12 @@ function displayNameCapitalized(user) {
   return nameUpperCase
 }
 
+function wait(time) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, time);
+  });
+}
+
 const arya = { name: null };
 const gendry = { name: 'Gendry' };
 
@@ -24,8 +30,7 @@ try {
   console.log('Gendry name:', gendryName)
 } handle (effect) {
   if (effect === 'ask_name') {
-    setTimeout(() => {
-      resume 'Arya Stark';
-   }, 1000);
+    await wait(1000);
+    resume 'Arya Stark';
   }
 }

--- a/samples/basic.js
+++ b/samples/basic.js
@@ -22,7 +22,7 @@ try {
   const gendryName = displayNameCapitalized(gendry);
   console.log('Arya name:', aryaName)
   console.log('Gendry name:', gendryName)
-} handle {
+} handle (effect) {
   if (effect === 'ask_name') {
     setTimeout(() => {
       resume 'Arya Stark';


### PR DESCRIPTION
After nice discussions, the second version of this proposals comes with the following changes:

- add parameter on `handle` block, to avoid shadowing problem and give more symmetry with `catch` block (https://github.com/macabeus/js-proposal-algebraic-effects/issues/16)
- doesn't allow to use `resume` outside of `handle` block AND must be in `handle` block directly  (https://github.com/macabeus/js-proposal-algebraic-effects/issues/8) (https://github.com/macabeus/js-proposal-algebraic-effects/issues/9)
- throw error if there is an unhandled effect (https://github.com/macabeus/js-proposal-algebraic-effects/issues/8#issuecomment-570058274)
- `perform` always should return a value, even if no `resume` is called (https://github.com/macabeus/js-proposal-algebraic-effects/issues/8#issuecomment-570052778)

(each commit is one of the changes above)

### TODOs

We still need to discuss more about:
- [Should we implicitly inject the effects? No @@?](https://github.com/macabeus/js-proposal-algebraic-effects/issues/3)
- [How will the effect interact with the ecosystem of TypeScript?](https://github.com/macabeus/js-proposal-algebraic-effects/issues/13)
- [Alternative Syntax to avoid new keywords](https://github.com/macabeus/js-proposal-algebraic-effects/issues/14)
- [When we could use perform expression?](https://github.com/macabeus/js-proposal-algebraic-effects/issues/12)